### PR TITLE
Add HTC Wildfire S (marvel) to the list of builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,9 @@ case "$DEVICE" in
    toroplus)
        device="toroplus"
        echo -e "${cya}Building ${bldcya}ParanoidAndroid v$VERSION ${txtrst}${cya}for Sprint Samsung Galaxy Nexus ${txtrst}";;
+   marvel)
+       device="marvel"
+       echo -e "${cya}Building ${bldcya}ParanoidAndroid v$VERSION ${txtrst}${cya}for The HTC Wildfire S ${txtrst}";;
    *)
        echo -e "${bldred}Wrong input, please select a valid device ${txtrst}"
        exit;;


### PR DESCRIPTION
I would like to add the Wildfire S to the list of official devices running ParanoidAndroid. The thread for the port is here (http://forum.xda-developers.com/showthread.php?t=1749474) and my main repo is here (https://github.com/dudeman1996/paranoidandroid_marvel).

Thanks! :)
