### PR TITLE
Jellybean

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -21,11 +21,11 @@ Make sure you have your device tree sources, located on
 
 Now you can run our build script:
 
-    ./rom-build.sh <device>
+    ./build.sh <device>
 
 You can also use a second parameter for syncing sources before building
 
-    ./rom-build.sh <device> true
+    ./build.sh <device> true
 
 There are also a few parameters that you can use together with before mentioned:
 
@@ -34,7 +34,7 @@ There are also a few parameters that you can use together with before mentioned:
 
 The usage is the same
 
-    ./rom-build.sh <device> <parameters> <sync>
+    ./build.sh <device> <parameters> <sync>
 
 Parameters will be considered false unless you set them to true
 
@@ -43,8 +43,9 @@ This will make a signed zip located on out/target/product/<device>.
 There are some optional parameters you might use:
 * PREFS_FROM_SOURCE: Use it to enable build of PA Preferences application (available only for core PA team)
 * USE_CCACHE: Use it to improve consequent build speed. You also might CCACHE_DIR to specify alternate cache location which by default is on ~/./ccache. Very useful when home folder encryption is used.
+* INTERACTIVE: Use to enter interactive shell with build environment set up, instead of automatice build.
 
-    ```env USE_CCACHE=true PREFS_FROM_SOURCE=true ./rom-build.sh <device> <parameters> <sync>```
+    ```env [USE_CCACHE=true] [PREFS_FROM_SOURCE=true] [INTERACTIVE=true] ./build.sh <device> <parameters> <sync>```
 
 Contribute with the project
 ---------------------------

--- a/README.mkdn
+++ b/README.mkdn
@@ -14,20 +14,18 @@ Then sync it up (This will take a while, so get a cup of coffee and some snicker
 
 Building ParanoidAndroid
 ------------------------
-
 For building ParanoidAndroid you must cd to the working directory.
 Make sure you have your device tree sources, located on
 
-    cd device/-manufacturer-/-device-
+    cd device/<manufacturer>/<device>
 
 Now you can run our build script:
 
-    ./rom-build.sh -device-
-
+    ./rom-build.sh <device>
 
 You can also use a second parameter for syncing sources before building
 
-    ./rom-build.sh -device- true
+    ./rom-build.sh <device> true
 
 There are also a few parameters that you can use together with before mentioned:
 
@@ -35,16 +33,19 @@ There are also a few parameters that you can use together with before mentioned:
 * clean: Removes intermediates and output files
 
 The usage is the same
-    
-    ./rom-build.sh -device- -parameters- -sync-
+
+    ./rom-build.sh <device> <parameters> <sync>
 
 Parameters will be considered false unless you set them to true
 
-This will make a signed zip located on out/target/product/-device-.
+This will make a signed zip located on out/target/product/<device>.
+
+There are some optional parameters you might use:
+* PREFS_FROM_SOURCE: Use it to enable build of PA Preferences application (available only for core PA team)
+* USE_CCACHE: Use it to improve consequent build speed. You also might CCACHE_DIR to specify alternate cache location which by default is on ~/./ccache. Very useful when home folder encryption is used.
+
+    ```env USE_CCACHE=true PREFS_FROM_SOURCE=true ./rom-build.sh <device> <parameters> <sync>```
 
 Contribute with the project
 ---------------------------
-
 We're an open source project, and we're open to suggestions. Feel free to sumbit patches to our [Gerrit](http://review.paranoid-rom.com/)
-
-

--- a/build.sh
+++ b/build.sh
@@ -110,6 +110,9 @@ if [ "$SYNC" == "true" ]; then
 	echo -e ""
 fi
 
+echo -e "${bldblu}Saving build manifest${txtrst}"
+repo manifest -o vendor/pa/prebuilt/common/etc/build-manifest.xml -r
+
 if [ -r vendor/cm/get-prebuilts ]; then
 	if [ -r vendor/cm/proprietary/.get-prebuilts ]; then
 		echo -e "${bldgrn}Already downloaded prebuilts${txtrst}"
@@ -134,26 +137,31 @@ else
 	echo -e "${bldcya}Not CM/PA tree, skipping prebuilts${txtrst}"
 fi
 
-# setup environment
-echo -e ""
-echo -e "${bldblu}Setting up environment${txtrst}"
-. build/envsetup.sh
-
-# lunch/brunch device
-if [ -d vendor/pa ]; then
-	echo -e ""
-	echo -e "${bldblu}Lunching device [$DEVICE]${txtrst}"
-	export PREFS_FROM_SOURCE
-	lunch "pa_$DEVICE-userdebug";
-
-	echo -e "${bldblu}Starting compilation${txtrst}"
-	mka bacon
-	echo -e ""
+if [ -n "${INTERACTIVE}" ]; then
+		echo -e "${bldblu}Dropping to interactive shell${txtrst}"
+		echo -e "${bldblu}Remeber to lunch you device [${bldgrn}lunch pa_$DEVICE-userdebug${bldblu}]${txtrst}"
+		bash --init-file build/envsetup.sh -i
 else
+	# setup environment
 	echo -e ""
-	echo -e "${bldblu}Brunching device [$DEVICE]${txtrst}"
-	brunch $DEVICE
-	echo -e ""
+	echo -e "${bldblu}Setting up environment${txtrst}"
+	. build/envsetup.sh
+
+	# lunch/brunch device
+	if [ -d vendor/pa ]; then
+		echo -e ""
+		echo -e "${bldblu}Lunching device [$DEVICE]${txtrst}"
+		export PREFS_FROM_SOURCE
+		lunch "pa_$DEVICE-userdebug";
+
+		echo -e "${bldblu}Starting compilation${txtrst}"
+		mka bacon
+		echo -e ""
+	else
+		echo -e "${bldblu}Brunching device [$DEVICE]${txtrst}"
+		brunch $DEVICE
+		echo -e ""
+	fi
 fi
 
 if [ -n "${CCACHE_DIR}" ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-# get current path
-reldir=`dirname $0`
-cd $reldir
-DIR=`pwd`
+# Get current path
+DIR="$(cd `dirname $0`; pwd)"
 
 # Colorize and add text parameters
 red=$(tput setaf 1)             #  red
 grn=$(tput setaf 2)             #  green
+blu=$(tput setaf 4)             #  blue
 cya=$(tput setaf 6)             #  cyan
 txtbld=$(tput bold)             # Bold
 bldred=${txtbld}$(tput setaf 1) #  red
@@ -16,76 +15,153 @@ bldblu=${txtbld}$(tput setaf 4) #  blue
 bldcya=${txtbld}$(tput setaf 6) #  cyan
 txtrst=$(tput sgr0)             # Reset
 
-THREADS="16"
+# Local defaults, can be overriden by env.
+: ${PREFS_FROM_SOURCE:="false"}
+#: ${USE_CCACHE="true"}
+#: ${CCACHE_DIR:="$DIR/../ccache"}
+: ${THREADS="16"}
+
 DEVICE="$1"
 EXTRAS="$2"
 
 # get current version
-MAJOR=$(cat $DIR/vendor/pa/config/pa_common.mk | grep 'PA_VERSION_MAJOR = *' | sed  's/PA_VERSION_MAJOR = //g')
-MINOR=$(cat $DIR/vendor/pa/config/pa_common.mk | grep 'PA_VERSION_MINOR = *' | sed  's/PA_VERSION_MINOR = //g')
-MAINTENANCE=$(cat $DIR/vendor/pa/config/pa_common.mk | grep 'PA_VERSION_MAINTENANCE = *' | sed  's/PA_VERSION_MAINTENANCE = //g')
-VERSION=$MAJOR.$MINOR$MAINTENANCE
+if [ -r vendor/pa/config/pa_common.mk ]; then
+	VENDOR="pa"
+	MAJOR=$(cat $DIR/vendor/pa/config/pa_common.mk | grep 'PA_VERSION_MAJOR = *' | sed  's/PA_VERSION_MAJOR = //g')
+	MINOR=$(cat $DIR/vendor/pa/config/pa_common.mk | grep 'PA_VERSION_MINOR = *' | sed  's/PA_VERSION_MINOR = //g')
+	MAINTENANCE=$(cat $DIR/vendor/pa/config/pa_common.mk | grep 'PA_VERSION_MAINTENANCE = *' | sed  's/PA_VERSION_MAINTENANCE = //g')
+elif [ -r vendor/cm/config/common.mk ]; then
+	VENDOR="cm"
+	MAJOR=$(cat $DIR/vendor/cm/config/common.mk | grep 'PRODUCT_VERSION_MAJOR = *' | sed  's/PRODUCT_VERSION_MAJOR = //g')
+	MINOR=$(cat $DIR/vendor/cm/config/common.mk | grep 'PRODUCT_VERSION_MINOR = *' | sed  's/PRODUCT_VERSION_MINOR = //g')
+	MAINTENANCE=$(cat $DIR/vendor/cm/config/common.mk | grep 'PRODUCT_VERSION_MAINTENANCE = *' | sed  's/PRODUCT_VERSION_MAINTENANCE = //g')
+else
+	VENDOR="aosp"
+	MAJOR=4
+	MINOR=2
+	MAINTENANCE=1
+fi
+VERSION=$VENDOR-$MAJOR.$MINOR$MAINTENANCE
 
 # if we have not extras, reduce parameter index by 1
-if [ "$EXTRAS" == "true" ] || [ "$EXTRAS" == "false" ]
-then
-   SYNC="$2"
-   UPLOAD="$3"
+if [ "$EXTRAS" == "true" ] || [ "$EXTRAS" == "false" ]; then
+	SYNC="$2"
+	UPLOAD="$3"
 else
-   SYNC="$3"
-   UPLOAD="$4"
+	SYNC="$3"
+	UPLOAD="$4"
 fi
 
 # get time of startup
 res1=$(date +%s.%N)
 
+# get ccache size at start
+if [ -n "${USE_CCACHE}" ]; then
+	export USE_CCACHE
+	if [ -n "${CCACHE_DIR}" ]; then
+		export CCACHE_DIR
+		[ ! -d "${CCACHE_DIR}" ] && mkdir -p "${CCACHE_DIR}" && chmod ug+rwX "${CCACHE_DIR}"
+		cache1=$(du -sh ${CCACHE_DIR} | awk '{print $1}')
+	fi
+fi
+
 # we don't allow scrollback buffer
 echo -e '\0033\0143'
 clear
 
-echo -e "${cya}Building ${bldcya}ParanoidAndroid v$VERSION ${txtrst}";
+echo -e "${cya}Building ${bldcya}Android $VERSION for $DEVICE${txtrst}";
+echo -e "${bldgrn}Start time: $(date) ${txtrst}"
 
-echo -e "${cya}"
-./vendor/pa/tools/getdevicetree.py $DEVICE
-echo -e "${txtrst}"
+[ -n "${USE_CCACHE}" ] && echo -e "${cya}Building using CCACHE${txtrst}"
+[ -n "${CCACHE_DIR}" ] && echo -e "${bldgrn}CCACHE: location = [${txtrst}${grn}${CCACHE_DIR}${bldgrn}], size = [${txtrst}${grn}${cache1}${bldgrn}]${txtrst}"
+
+if [ -d vendor/pa ]; then
+	echo -e "${cya}"
+	./vendor/pa/tools/getdevicetree.py $DEVICE
+	echo -e "${txtrst}"
+else
+	echo -e "${bldcya}Not PA tree, skipping prebuilts${txtrst}"
+fi
+
 
 # decide what command to execute
 case "$EXTRAS" in
-   threads)
-       echo -e "${bldblu}Please write desired threads followed by [ENTER] ${txtrst}"
-       read threads
-       THREADS=$threads;;
-   clean)
-       echo -e ""
-       echo -e "${bldblu}Cleaning intermediates and output files ${txtrst}"
-       make clean > /dev/null;;
+	threads)
+		echo -e "${bldblu}Please write desired threads followed by [ENTER]${txtrst}"
+		read threads
+		THREADS=$threads
+	;;
+	clean|cclean)
+		echo -e "${bldblu}Cleaning intermediates and output files${txtrst}"
+		rm -f vendor/pa/prebuilt/common/.get-prebuilts vendor/cm/proprietary/.get-prebuilts
+		if [ $EXTRAS == cclean ] && [ -n "${CCACHE_DIR}" ]; then
+			echo "${bldblu}Cleaning ccache${txtrst}"
+			prebuilts/misc/linux-x86/ccache/ccache -C -M 5G
+		fi
+		make clean > /dev/null
+	;;
 esac
 
 # sync with latest sources
-echo -e ""
-if [ "$SYNC" == "true" ]
-then
-   echo -e "${bldblu}Fetching latest sources ${txtrst}"
-   repo sync -j"$THREADS"
-   echo -e ""
+if [ "$SYNC" == "true" ]; then
+	echo -e ""
+	echo -e "${bldblu}Fetching latest sources${txtrst}"
+	repo sync -j"$THREADS"
+	echo -e ""
+fi
+
+if [ -r vendor/cm/get-prebuilts ]; then
+	if [ -r vendor/cm/proprietary/.get-prebuilts ]; then
+		echo -e "${bldgrn}Already downloaded prebuilts${txtrst}"
+	else
+		echo -e "${bldblu}Downloading prebuilts${txtrst}"
+		pushd vendor/cm > /dev/null
+		rm -f proprietary/.get-prebuilts
+		./get-prebuilts && touch proprietary/.get-prebuilts
+		popd > /dev/null
+	fi
+elif [ -r vendor/pa/get-prebuilts ]; then
+	if [ -r vendor/pa/prebuilt/common/.get-prebuilts ]; then
+		echo -e "${bldgrn}Already downloaded prebuilts${txtrst}"
+	else
+		echo -e "${bldblu}Downloading prebuilts${txtrst}"
+		pushd vendor/pa > /dev/null
+		rm -f prebuilt/common/.get-prebuilts
+		./get-prebuilts && touch prebuilt/common/.get-prebuilts
+		popd > /dev/null
+	fi
+else
+	echo -e "${bldcya}Not CM/PA tree, skipping prebuilts${txtrst}"
 fi
 
 # setup environment
-echo -e "${bldblu}Setting up environment ${txtrst}"
+echo -e ""
+echo -e "${bldblu}Setting up environment${txtrst}"
 . build/envsetup.sh
 
-# lunch device
-echo -e ""
-echo -e "${bldblu}Lunching device ${txtrst}"
-lunch "pa_$DEVICE-userdebug";
+# lunch/brunch device
+if [ -d vendor/pa ]; then
+	echo -e ""
+	echo -e "${bldblu}Lunching device [$DEVICE]${txtrst}"
+	export PREFS_FROM_SOURCE
+	lunch "pa_$DEVICE-userdebug";
 
-echo -e ""
-echo -e "${bldblu}Starting compilation ${txtrst}"
+	echo -e "${bldblu}Starting compilation${txtrst}"
+	mka bacon
+	echo -e ""
+else
+	echo -e ""
+	echo -e "${bldblu}Brunching device [$DEVICE]${txtrst}"
+	brunch $DEVICE
+	echo -e ""
+fi
 
-# start compilation
-mka bacon
-echo -e ""
+if [ -n "${CCACHE_DIR}" ]; then
+	# get ccache size
+	cache2=$(du -sh ${CCACHE_DIR} | awk '{print $1}')
+	echo -e "${bldgrn}cccache size is ${txtrst} ${grn}${cache2}${txtrst} (was ${grn}${cache1}${txtrst})"
+fi
 
 # finished? get elapsed time
 res2=$(date +%s.%N)
-echo "${bldgrn}Total time elapsed: ${txtrst}${grn}$(echo "($res2 - $res1) / 60"|bc ) minutes ($(echo "$res2 - $res1"|bc ) seconds) ${txtrst}"
+echo -e "${bldgrn}Total time elapsed: ${txtrst}${grn}$(echo "($res2 - $res1) / 60"|bc ) minutes ($(echo "$res2 - $res1"|bc ) seconds)${txtrst}"

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,7 @@ txtrst=$(tput sgr0)             # Reset
 
 # Local defaults, can be overriden by env.
 : ${PREFS_FROM_SOURCE:="false"}
+#: ${PREBUILTS_ALL:="true"}
 #: ${USE_CCACHE:="true"}
 #: ${CCACHE_NOSTATS:="true"}
 #: ${CCACHE_DIR:="$DIR/../ccache"}
@@ -125,6 +126,7 @@ fi
 echo -e "${bldblu}Saving build manifest${txtrst}"
 repo manifest -o vendor/pa/prebuilt/common/etc/build-manifest.xml -r
 
+export PREBUILTS_ALL
 if [ -r vendor/cm/get-prebuilts ]; then
 	if [ -r vendor/cm/proprietary/.get-prebuilts ]; then
 		echo -e "${bldgrn}Already downloaded prebuilts${txtrst}"
@@ -178,7 +180,7 @@ fi
 
 if [ -n "${CCACHE_DIR}" ]; then
 	# get ccache size
-	if [ "${CCACHE_NOSTATS}" == "true" ] && ; then
+	if [ "${CCACHE_NOSTATS}" == "true" ]; then
 		cache2=$(du -sh ${CCACHE_DIR} | awk '{print $1}')
 	else
 		cache2=$(prebuilts/misc/linux-x86/ccache/ccache -s | grep "^cache size" | awk '{print $3$4}')


### PR DESCRIPTION
Note: default behavior should be the same as before!
- Rename build script from rom-build.sh to build.sh
- Fixed cosmetic issues
- Control PAPrefs build/install procedure by environment variable
- New features:
  - ccache support (works with prebuilt ccache but works much better with system one, requires changes to "build")
  - prebuilts support (requires prebuilts chnages to "vendor_pa")
  - interactive shell
  - save build manifest (like CM do, for better re-constructibility)
